### PR TITLE
Tabs should be expanded based on their position in the line

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -162,15 +162,16 @@ point and encoded in UTF-8 encoding.
 The [document] consists of a sequence of [characters], where the
 [characters] may represent either markup or character data.
 
-A U+0009 (TAB) character in the input shall be treated as four
-consecutive U+0020 (SPACE) characters.
-
 <span id="space">
 A U+0020 (SPACE) character is henceforth called a **space** character.
 </span>
 <span id="non-space">
 Any character that is not a U+0020 (SPACE) character is henceforth
 called a **non-space** character.
+</span>
+
+<span id="tab">
+A U+0009 (TAB) character is henceforth called a **tab** character.
 </span>
 
 The character sequence of a U+000D (CR) character followed by a U+000A
@@ -187,7 +188,7 @@ Any [character] that is not a _line break_ character is called a
 
 <span id="whitespace">
 A **whitespace** character is one of the following characters:
-U+000A (LF), U+000C (FF), U+000D (CR) or U+0020 (SPACE)
+U+0009 (TAB), U+000A (LF), U+000C (FF), U+000D (CR) or U+0020 (SPACE)
 </span>
 
 <span id="string">
@@ -241,6 +242,7 @@ called the **enclosed string** of the [quoted string].</span>
 
 [space]: #space
 [non-space]: #non-space
+[tab]: #tab
 [line break]: #line-break
 [line breaks]: #line-break
 [non-line-break]: #non-line-break
@@ -268,8 +270,28 @@ breaks].
 
 <span id="blank-line">
 If a [line] contains no [characters], or if all [characters] in the
-[line] are [space] characters, that line is called a **blank line**.
-</span>
+[line] are [space] or [tab] characters, that line is called a
+**blank line**.</span>
+
+The [lines] in the [document] shall be preprocessed to expand each [tab]
+character in the line to a certain number of [space] characters, as
+specified below:
+
+ 1. Let _p_ be the position of the [tab] character in the [line], after
+    all previous [tab] characters in the [line] have been "expanded".
+
+    For the first character of a [line], the position of the character
+    is considered to be 0; for the second character of the [line], the
+    position of the character is considered to be 1, and so on.
+
+ 2. Compute _n_ as: ( 4 - ( _p_ % 4 ) ), where '%' is the modulo operator
+
+ 3. "Expand" the [tab] character by replacing it with _n_ number of
+    [space] characters
+
+Since all the [lines] in a [document] are tab-expanded as specified
+above, for the following discussion, the [document] is considered not to
+have any [tab] characters.
 
 To [identify the block-elements] in the [document], the [document] is seen
 as a sequence of [lines].

--- a/syntax.md
+++ b/syntax.md
@@ -32,8 +32,9 @@ and inline-code.
 
 ## Table of contents
 
-  * [Encoding]
-  * [Tabs]
+  * [Basics]
+      * [Encoding]
+      * [Tabs]
   * [Block-level elements]
       * [Paragraphs]
       * [Headers]
@@ -54,7 +55,11 @@ and inline-code.
       * [Using vfmd along with HTML markup]
       * [Verbatim HTML]
 
-<h2 id="encoding">Encoding</h2>
+<h2 id="basics">Basics</h2>
+
+[Basics]: #basics
+
+<h3 id="encoding">Encoding</h3>
 
 [Encoding]: #encoding
 
@@ -64,7 +69,7 @@ another language, please make sure that the document is in UTF-8
 encoding (for example, if you are using a text editor to write the
 document, ensure that it saves the document in UTF-8 encoding).
 
-<h2 id="tabs">Tabs</h2>
+<h3 id="tabs">Tabs</h3>
 
 [Tabs]: #tabs
 

--- a/syntax.md
+++ b/syntax.md
@@ -184,7 +184,7 @@ not be identified as a header.
 
 Code blocks can be used to quote text verbatim. For example, it can be
 used to quote source code. Every line of the code block should be
-indented by 4 space characters (or 1 tab character).
+indented by 4 space characters.
 
 No Markdown syntax is processed within a code block. In addition, for
 HTML output, ampersands (`&`) and angle brackets (`<` and `>`) within a
@@ -430,8 +430,7 @@ item.
         > inside a list item
 
     -   List item with a code-block. The code-block should be indented
-        by 4 spaces (or 1 tab) from the starting position of this
-        paragraph.
+        by 4 spaces from the starting position of this paragraph.
 
             int main() {
                 return 42;
@@ -1118,7 +1117,7 @@ The corresponding HTML output shall be:
 
 However, please make sure that the starting line of each snippet of HTML
 is not indented by more than 3 spaces (if it's indented by 4 or more
-spaces, or a tab, it would become a [code block]).
+spaces, it would become a [code block]).
 
 On the contrary, if you want the whole block of HTML reproduced verbatim
 in the HTML output, make sure that there are no blank lines in the

--- a/syntax.md
+++ b/syntax.md
@@ -33,6 +33,7 @@ and inline-code.
 ## Table of contents
 
   * [Encoding]
+  * [Tabs]
   * [Block-level elements]
       * [Paragraphs]
       * [Headers]
@@ -62,6 +63,15 @@ document in English, it is most likely in UTF-8. If you are writing in
 another language, please make sure that the document is in UTF-8
 encoding (for example, if you are using a text editor to write the
 document, ensure that it saves the document in UTF-8 encoding).
+
+<h2 id="tabs">Tabs</h2>
+
+[Tabs]: #tabs
+
+vfmd assumes 4-column tab stops when dealing with tab characters in the
+input. If you are using a text editor to write the text, please
+configure your editor to either use 4-column tab stops, or to expand
+tabs to spaces as you type.
 
 <h2 id="block-level-elements">Block-level elements</h2>
 


### PR DESCRIPTION
This pull-request addresses issue vfmd/vfmd-spec#2

Specification:
- Expands tab characters based on their position rather than always expanding them to 4 spaces

Syntax guide:
- Refrains from using the tab terminology because actually, the implementation is unaware of tabs. 
  
  For example:
  
  ```
  >[TAB]something
  ```
  
  will not be recognized as codeblock within a blockquote as per the specification. Therefore, we should not say in the userguide that users can get a code-block by starting the line with either 4 spaces or 1 tab. Only 4 spaces will work consistently.
- Explains about how tab characters are handled in a note at the start of the guide
